### PR TITLE
[WIP] Fix fetch relationships in "full" mode

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -2,6 +2,7 @@ import clone from '@chialab/proteins/src/clone.js';
 import { internal } from '@chialab/synapse/src/helpers/internal.js';
 import { AjaxCollection } from '@chialab/synapse/src/collections/ajax.js';
 import { Model } from './model.js';
+import { merge } from '@chialab/proteins';
 
 export class Collection extends AjaxCollection {
     static create(Model) {
@@ -162,6 +163,12 @@ export class Collection extends AjaxCollection {
         return Promise.resolve(res.data);
     }
 
+    /**
+     * Fetch all objects in the collection.
+     * 
+     * @param {Object} options Additional options.
+     * @return {Promise}
+     */
     findAll(options = {}) {
         options = clone(options);
         let Entity = options.Model || this.constructor.Model;
@@ -228,19 +235,28 @@ export class Collection extends AjaxCollection {
 
         let promise = super.findAll(options);
         if (options.full) {
-            // Load all results by fetching all pages one after the other.
-            let currentPage = options.page || 1;
-            promise = promise.then((res) => {
+            // Load all results by fetching all pages in parallel.
+            const currentPage = options.page || 1;
+            promise = promise.then(() => {
                 if (!this.pagination || this.pagination.page_count <= currentPage) {
-                    return Promise.resolve(res);
+                    return Promise.resolve();
                 }
 
-                return this.getCleanCopy().then((collection) => {
-                    options.page = currentPage + 1;
-                    return collection.findAll(options).then(() =>
-                        this.joinCollection(collection)
+                const allPromises = [];
+                for (let page = currentPage + 1; page <= this.pagination.page_count; page++) {
+                    allPromises.push(
+                        this.getCleanCopy()
+                            .then(collection =>
+                                collection.findAll(merge(options, { page, full: false }))
+                                    .then(() => Promise.resolve(collection))
+                            )
                     );
-                });
+                }
+
+                return Promise.all(allPromises)
+                    .then(pages => {
+                        pages.forEach(page => this.joinCollection(page));
+                    });
             });
         }
 
@@ -316,7 +332,9 @@ export class Collection extends AjaxCollection {
      * @return {Promise}
      */
     joinCollection(collection) {
-        return Promise.all(collection.map((model) => this.add(model)));
+        this.add(...collection.array);
+
+        return Promise.resolve();
     }
 
     /**

--- a/src/collections/relationships.js
+++ b/src/collections/relationships.js
@@ -321,7 +321,12 @@ export class RelationshipsCollection extends Collection {
 
     /** @inheritdoc */
     joinCollection(collection) {
-        return super.joinCollection(collection)
+        let joinPromise = Promise.resolve();
+        if (this.parent !== collection.parent) {
+            joinPromise = super.joinCollection(collection);
+        }
+
+        return joinPromise
             .then(() => {
                 this.paramsList = this.paramsList || [];
                 this.paramsList.push(...(collection.paramsList || []));


### PR DESCRIPTION
This PR fixes a misbehaviour when trying to fetch relationships for an object in "full" mode (= all pages of related objects at once). When two `Relationships` collections share the same parent, we no longer merge them as they already store their values in the same place, so any merge would actually duplicate results.