### PR TITLE
Autodetect parent model constructor using api

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -56,7 +56,9 @@ export class Collection extends AjaxCollection {
     model(data, EntityModel) {
         let resolveModel;
         if (!EntityModel && data && data.type) {
-            resolveModel = this.factory('model').getModel(data.type, this.constructor.Model);
+            resolveModel = this.factory('model')
+                .getModel(data.type, this.constructor.Model)
+                .catch(() => this.constructor.Model);
         } else {
             resolveModel = Promise.resolve(EntityModel || this.constructor.Model);
         }

--- a/src/collections/applications.js
+++ b/src/collections/applications.js
@@ -1,11 +1,22 @@
 import { Collection } from '../collection.js';
 import { ApplicationModel } from '../models/application.js';
 
+/**
+ * @class bedita.ApplicationsCollection
+ * @extends bedita.Collection
+ * A collection for ApplicationModels.
+ */
 export class ApplicationsCollection extends Collection {
+    /**
+     * @inheritdoc
+     */
     static get Model() {
         return ApplicationModel;
     }
 
+    /**
+     * @inheritdoc
+     */
     getMinimalPropertiesSet() {
         return Promise.resolve(['id', 'api_key', 'name', 'description']);
     }

--- a/src/collections/media.js
+++ b/src/collections/media.js
@@ -1,7 +1,15 @@
 import { Collection } from '../collection.js';
 import { MediaModel } from '../models/media.js';
 
+/**
+ * @class bedita.MediaCollection
+ * @extends bedita.Collection
+ * A collection for MediaModels.
+ */
 export class MediaCollection extends Collection {
+    /**
+     * @inheritdoc
+     */
     static get Model() {
         return MediaModel;
     }

--- a/src/collections/object_types.js
+++ b/src/collections/object_types.js
@@ -2,38 +2,34 @@ import { Collection } from '../collection.js';
 import { ObjectTypeModel } from '../models/object_type.js';
 
 /**
- * Object Types Collection
+ * @class bedita.ObjectTypesCollection
+ * @extends bedita.Collection
+ * A collection for ObjectTypeModels.
  */
 export class ObjectTypesCollection extends Collection {
-
     /**
-     * Return object type model
-     * 
-     * @return {ObjectTypeModel} object type model
+     * @inheritdoc
      */
     static get Model() {
         return ObjectTypeModel;
     }
 
     /**
-     * The endpoint for ObjectTypes.
-     * @type {String}
+     * @inheritdoc
      */
     get defaultEndpoint() {
         return '/model/object_types';
     }
 
     /**
-     * Return minimal properties set for index pages
-     * 
-     * @return {Promise<Array>} properties set
+     * @inheritdoc
      */
     getMinimalPropertiesSet() {
         return Promise.resolve(['id', 'name', 'is_abstract', 'description']);
     }
 
     /**
-     * call Collection.findAll with custom endpoint for available object_types for a collection
+     * call Collection.findAll with custom endpoint for available object_types for a relation.
      * 
      * @param {String} relName The relationship name.
      * @param {Object} options 

--- a/src/factories/model.js
+++ b/src/factories/model.js
@@ -71,7 +71,13 @@ export class ModelFactory extends Factory {
                     .then((ParentModel) =>
                         this.getSchema(type)
                             .then((data) => {
-                                let TypedModel = ParentModel.create(type, data);
+                                let relations = {};
+                                if (objectType.metadata().relations) {
+                                    objectType.metadata().relations.forEach((rel) => {
+                                        relations[rel] = {};
+                                    });
+                                }
+                                let TypedModel = ParentModel.create(type, data, relations);
                                 this.registerModel(TypedModel);
                                 return TypedModel;
                             })

--- a/src/models/base.js
+++ b/src/models/base.js
@@ -165,7 +165,7 @@ export class BaseModel extends Model {
                         collection.fetched = true;
                         return Promise.all(
                             rel.data.map((modelData) =>
-                                collection.model(modelData, Model)
+                                collection.model(modelData)
                                     .then((model) =>
                                         this.addRelationship(name, model)
                                     )

--- a/src/models/base.js
+++ b/src/models/base.js
@@ -5,14 +5,33 @@ const REL_KEY = 'relationships';
 const REL_META_KEY = 'relationshipsMeta';
 
 export class BaseModel extends Model {
+    /**
+     * @inheritdoc
+     */
+    static create(type, schema, relations) {
+        // handle relations
+        const Ctr = super.create(type, schema);
+        if (relations) {
+            Ctr.relationships = relations;
+        }
+        return Ctr;
+    }
+
+    /**
+     * @inheritdoc
+     */
     initialize(...args) {
         let ctrRelationships = this.constructor.relationships || {};
         return super.initialize(...args)
             .then(() =>
+                // setup object relationships collections.
                 this.setupRelationships(ctrRelationships)
             );
     }
 
+    /**
+     * @inheritdoc
+     */
     merge(model) {
         return super.merge(model)
             .then(() => {
@@ -37,11 +56,16 @@ export class BaseModel extends Model {
             });
     }
 
+    /**
+     * @inheritdoc
+     */
     reset(skipChanges) {
+        // reset relationships collections
         let rels = this.getRelationships() || {};
         Object.keys(rels).forEach((name) => {
             rels[name].reset(skipChanges);
         });
+        // reset relationships metadata
         this.set(REL_META_KEY, undefined, { internal: true });
         return super.reset(skipChanges);
     }
@@ -179,44 +203,94 @@ export class BaseModel extends Model {
         return collection.findAll(options).then(() => Promise.resolve(collection));
     }
 
-    addRelationship(name, model, params) {
-        let collection = this.getRelationship(name);
-        if (collection.getIndexByModel(model) === -1) {
-            collection.add(model);
+    /**
+     * Add a relationship.
+     * @memberof BaseModel
+     *
+     * @param {string} relName The name of the relationship to add.
+     * @param {Model} relModel The related model to add.
+     * @param {Object} [params] A set of relationship params.
+     * @return {void}
+     */
+    addRelationship(relName, relModel, params) {
+        let collection = this.getRelationship(relName);
+        if (collection.getIndexByModel(relModel) === -1) {
+            collection.add(relModel);
         }
         if (params) {
-            this.setRelationshipMeta(name, model, params, true);
+            this.setRelationshipMeta(relName, relModel, params, true);
         }
     }
 
-    removeRelationship(name, model) {
-        let collection = this.getRelationship(name);
-        return collection.remove(model);
+    /**
+     * Remove a relationship.
+     * @memberof BaseModel
+     *
+     * @param {string} relName The name of the relationship to remove.
+     * @param {Model} relModel The related model to remove.
+     * @return {void}
+     */
+    removeRelationship(relName, relModel) {
+        let collection = this.getRelationship(relName);
+        collection.remove(relModel);
     }
 
-    getRelationshipMeta(relName, model) {
+    /**
+     * Get relationship metadata.
+     * @memberof BaseModel
+     *
+     * @param {string} relName The name of the relationship.
+     * @param {Model} relModel The related model.
+     * @return {Object|void} A set of relationship metadata.
+     */
+    getRelationshipMeta(relName, relModel) {
         let relMeta = this.get(REL_META_KEY, { internal: true }) || {};
-        return relMeta[relName] && relMeta[relName][model.id];
+        return relMeta[relName] && relMeta[relName][relModel.id];
     }
 
-    setRelationshipMeta(relName, model, meta, trigger) {
-        let relMeta = this.get(REL_META_KEY, { internal: true }) || {};
+    /**
+     * Update relationship's metadata and parameters.
+     * @memberof BaseModel
+     *
+     * @param {string} relName The name of the relationship to update.
+     * @param {Model} relModel The related model.
+     * @param {Object} meta The new meta object to set.
+     * @param {Boolean} trigger Should trigger a change event.
+     * @return {void}
+     *
+     * @emits BaseModel#relparams:change A relationship param has changed.
+     */
+    setRelationshipMeta(relName, relModel, meta, trigger) {
+        // get all relationships metadata
+        const relMeta = this.get(REL_META_KEY, { internal: true }) || {};
+        // get relationship metadata
         relMeta[relName] = relMeta[relName] || {};
-        relMeta[relName][model.id] = meta;
+        // set metadata for the related model
+        relMeta[relName][relModel.id] = meta;
+        // update relationships metadata
         this.set(REL_META_KEY, relMeta, { internal: true });
         if (trigger) {
+            // trigger the change event
             this.trigger('relparams:change', {
                 name: relName,
                 left: this,
-                right: model,
+                right: relModel,
                 meta,
             });
         }
     }
 
+    /**
+     * Check if relationships are changed from the latest remote sync.
+     * @memberof BaseModel
+     *
+     * @return {Boolean}
+     */
     hasRelationshipsChanges() {
         let collections = this.getRelationships();
+        // iterate every relationship
         for (let k in collections) {
+            // and check if it has changes
             if (collections[k].hasChanges()) {
                 return true;
             }
@@ -224,13 +298,30 @@ export class BaseModel extends Model {
         return false;
     }
 
-    setRelationshipParam(relName, model, paramName, paramValue) {
-        let relMeta = this.getRelationshipMeta(relName, model) || {};
-        relMeta.params = relMeta.params || {};
+    /**
+     * Add a parameter to a model relationship.
+     * @memberof BaseModel
+     *
+     * @param {string} relName The name of the relation to update.
+     * @param {Model} relModel The related model.
+     * @param {string} paramName The name of the paramater to update.
+     * @param {*} paramValue The value to set.
+     * @return {void}
+     */
+    setRelationshipParam(relName, relModel, paramName, paramValue) {
+        // get all the parameters of the relationship.
+        let relMeta = this.getRelationshipMeta(relName, relModel) || {};
+        // setup the `params` field
+        if (!relMeta.params) {
+            relMeta.params = {};
+        }
+        // check if the paramater has to be updated
         if (relMeta.params[paramName] !== paramValue) {
             relMeta.params[paramName] = paramValue;
+            // flag the relationship metatdata has changed
             relMeta.changed = true;
-            this.setRelationshipMeta(relName, model, relMeta, true);
+            // update the model
+            this.setRelationshipMeta(relName, relModel, relMeta, true);
         }
     }
 }


### PR DESCRIPTION
This PR changes how we manage Model creation using `model/object_types` api. Instead of require the parent model constructor for `getModel` and `initModel` methods of the `model` factory, we use the `parent_name` attribute of the api response in order to correctly create the prototype chain of the required model.

Should fix #16 